### PR TITLE
Add replacers

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -12,6 +12,7 @@ pub enum GenMode {
     Get,
     Set,
     GetMut,
+    Replace,
 }
 
 fn attr_name(attr: &Attribute) -> Option<Ident> {
@@ -76,6 +77,15 @@ pub fn implement(field: &Field, mode: GenMode, params: GenParams) -> Tokens {
                             }
                         }
                     }
+                    GenMode::Replace => {
+                        quote! {
+                            #(#doc)*
+                            fn #fn_name(&mut self, val: #ty) -> #ty {
+                                use std::mem;
+                                mem::replace(&mut self.#field_name, val)
+                            }
+                        }
+                    }
                 },
                 // `#[get = "pub"]` or `#[set = "pub"]`
                 Some(Meta::NameValue(MetaNameValue {
@@ -108,6 +118,15 @@ pub fn implement(field: &Field, mode: GenMode, params: GenParams) -> Tokens {
                                 #(#doc)*
                                 #visibility fn #fn_name(&mut self) -> &mut #ty {
                                     &mut self.#field_name
+                                }
+                            }
+                        }
+                        GenMode::Replace => {
+                            quote! {
+                                #(#doc)*
+                                #visibility fn #fn_name(&mut self, val: #ty) -> #ty {
+                                    use std::mem;
+                                    mem::replace(&mut self.#field_name, val)
                                 }
                             }
                         }

--- a/tests/replacers.rs
+++ b/tests/replacers.rs
@@ -1,0 +1,130 @@
+#[macro_use]
+extern crate getset;
+
+use submodule::other::{Generic, Plain, Where};
+
+// For testing `pub(super)`
+mod submodule {
+    // For testing `pub(in super::other)`
+    pub mod other {
+        #[derive(Getters, Replacers)]
+        pub struct Plain {
+            /// A doc comment.
+            /// Multiple lines, even.
+            #[get] #[replace]
+            private_accessible: usize,
+
+            /// A doc comment.
+            #[get = "pub"] #[replace = "pub"]
+            public_accessible: usize,
+            // /// A doc comment.
+            // #[replace = "pub(crate)"]
+            // crate_accessible: usize,
+
+            // /// A doc comment.
+            // #[replace = "pub(super)"]
+            // super_accessible: usize,
+
+            // /// A doc comment.
+            // #[replace = "pub(in super::other)"]
+            // scope_accessible: usize,
+        }
+
+        impl Default for Plain {
+            fn default() -> Plain {
+                Plain {
+                    private_accessible: 17,
+                    public_accessible: 18,
+                }
+            }
+        }
+
+        #[derive(Getters, Replacers, Default)]
+        pub struct Generic<T: Copy + Clone + Default> {
+            /// A doc comment.
+            /// Multiple lines, even.
+            #[get] #[replace]
+            private_accessible: T,
+
+            /// A doc comment.
+            #[get = "pub"] #[replace = "pub"]
+            public_accessible: T,
+            // /// A doc comment.
+            // #[replace = "pub(crate)"]
+            // crate_accessible: usize,
+
+            // /// A doc comment.
+            // #[replace = "pub(super)"]
+            // super_accessible: usize,
+
+            // /// A doc comment.
+            // #[replace = "pub(in super::other)"]
+            // scope_accessible: usize,
+        }
+
+        #[derive(Getters, Replacers, Default)]
+        pub struct Where<T>
+        where
+            T: Copy + Clone + Default,
+        {
+            /// A doc comment.
+            /// Multiple lines, even.
+            #[get] #[replace]
+            private_accessible: T,
+
+            /// A doc comment.
+            #[get = "pub"] #[replace = "pub"]
+            public_accessible: T,
+            // /// A doc comment.
+            // #[replace = "pub(crate)"]
+            // crate_accessible: usize,
+
+            // /// A doc comment.
+            // #[replace = "pub(super)"]
+            // super_accessible: usize,
+
+            // /// A doc comment.
+            // #[replace = "pub(in super::other)"]
+            // scope_accessible: usize,
+        }
+
+        #[test]
+        fn test_plain() {
+            let val = Plain::default();
+            val.private_accessible();
+        }
+
+        #[test]
+        fn test_generic() {
+            let val = Generic::<usize>::default();
+            val.private_accessible();
+        }
+
+        #[test]
+        fn test_where() {
+            let val = Where::<usize>::default();
+            val.private_accessible();
+        }
+    }
+}
+
+#[test]
+fn test_plain() {
+    let mut val = Plain::default();
+    assert_eq!(18, val.replace_public_accessible(19));
+    assert_eq!(19, *val.public_accessible());
+}
+
+#[test]
+fn test_generic() {
+    let mut val = Generic::<usize>::default();
+    assert_eq!(usize::default(), val.replace_public_accessible(1));
+    assert_eq!(1, *val.public_accessible());
+}
+
+#[test]
+fn test_where() {
+    let mut val = Where::<usize>::default();
+    assert_eq!(usize::default(), val.replace_public_accessible(1));
+    assert_eq!(1, *val.public_accessible());
+}


### PR DESCRIPTION
Replacers are setters that return the old value instead of dropping it. They provide a much simpler way (compared to using `*_mut` and `std::mem::{replace, swap}`) to retrieve fields by value.

```rust
use std::mem;

#[derive(Getters, Replacers)]
struct Foo {
    a: String
}

let mut foo = Foo { "Hello world!".into() };

// old
let retrieved = mem::replace(foo.a_mut(), String::new());

// old
let mut retrieved = String::new();
mem::swap(&mut retrieved, foo.a_mut());

// new
let retrieved = foo.replace_a(String::new());
```

## Open questions:

- [ ] `replace_*` seems a bit long, should the methods be called `swap_*` instead? But they take a value like `replace`, not a mutable reference like `swap`…
- [ ] Alternatively, they *could* take a mutable reference and work like `swap`. This would make them more flexible and make it possible to chain them like `set_*`.