### PR TITLE
Struct attribute, RefSetters and Into trait

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,10 @@
+# Changes
+
+## [0.0.7]
+
+### Changed
+
+* Move Setters to RefSetters with ref_set method to set
+* Setters set is now consume struct for chaining on creation
+* Use Into in setter methods
+* Handle struct attribute

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,6 @@ appveyor = { repository = "https://github.com/Hoverbear/getset", service = "gith
 proc-macro = true
 
 [dependencies]
-quote = "0.5.2"
-syn = "0.13.10"
-proc-macro2 = { version = "0.3", default-features = false }
+quote = "0.6"
+syn = "0.15"
+proc-macro2 = { version = "0.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ Getset, we're ready to go!
 
 A procedural macro for generating the most basic getters and setters on fields.
 """
-version = "0.0.6"
+version = "0.0.7"
 authors = ["hoverbear <andrew@hoverbear.org>"]
 license = "MIT"
 

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -13,6 +13,7 @@ pub struct GenParams {
 pub enum GenMode {
     Get,
     Set,
+    RefSet,
     GetMut,
 }
 
@@ -106,11 +107,21 @@ pub fn implement(field: &Field, mode: &GenMode, params: &GenParams) -> Tokens {
                     }
                 }
             }
-            GenMode::Set => {
+            GenMode::RefSet => {
                 quote! {
                     #(#doc)*
                     #[inline(always)]
                     #visibility fn #fn_name(&mut self, val: #ty) -> &mut Self {
+                        self.#field_name = val;
+                        self
+                    }
+                }
+            }
+            GenMode::Set => {
+                quote! {
+                    #(#doc)*
+                    #[inline(always)]
+                    #visibility fn #fn_name(mut self, val: #ty) -> Self {
                         self.#field_name = val;
                         self
                     }

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -110,8 +110,8 @@ pub fn implement(field: &Field, mode: &GenMode, params: &GenParams) -> TokenStre
                 quote! {
                     #(#doc)*
                     #[inline(always)]
-                    #visibility fn #fn_name(&mut self, val: #ty) -> &mut Self {
-                        self.#field_name = val;
+                    #visibility fn #fn_name(&mut self, val: impl Into<#ty>) -> &mut Self {
+                        self.#field_name = val.into();
                         self
                     }
                 }
@@ -120,8 +120,8 @@ pub fn implement(field: &Field, mode: &GenMode, params: &GenParams) -> TokenStre
                 quote! {
                     #(#doc)*
                     #[inline(always)]
-                    #visibility fn #fn_name(mut self, val: #ty) -> Self {
-                        self.#field_name = val;
+                    #visibility fn #fn_name(mut self, val: impl Into<#ty>) -> Self {
+                        self.#field_name = val.into();
                         self
                     }
                 }

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -66,8 +66,8 @@ pub fn parse_visibility(attr: Option<&Meta>, meta_name: &str) -> Option<Ident> {
 
 pub fn implement(field: &Field, mode: &GenMode, params: &GenParams) -> Tokens {
     let field_name = field
-        .clone()
         .ident
+        .as_ref()
         .expect("Expected the field to have a name");
     let fn_name = Term::new(
         &format!(
@@ -76,7 +76,7 @@ pub fn implement(field: &Field, mode: &GenMode, params: &GenParams) -> Tokens {
         ),
         Span::call_site(),
     );
-    let ty = field.ty.clone();
+    let ty = &field.ty;
 
     let mut doc = Vec::new();
     let attr = field

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,5 +1,4 @@
-use proc_macro2::{Span, Term};
-use quote::Tokens;
+use proc_macro2::{Span, TokenStream};
 use syn::{Attribute, Field, Ident, Lit, Meta, MetaList, MetaNameValue, NestedMeta};
 
 pub struct GenParams {
@@ -64,12 +63,12 @@ pub fn parse_visibility(attr: Option<&Meta>, meta_name: &str) -> Option<Ident> {
     }
 }
 
-pub fn implement(field: &Field, mode: &GenMode, params: &GenParams) -> Tokens {
+pub fn implement(field: &Field, mode: &GenMode, params: &GenParams) -> TokenStream {
     let field_name = field
         .ident
         .as_ref()
         .expect("Expected the field to have a name");
-    let fn_name = Term::new(
+    let fn_name = Ident::new(
         &format!(
             "{}{}{}",
             params.fn_name_prefix, field_name, params.fn_name_suffix

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,24 +11,25 @@ These macros are not intended to be used on fields which require custom logic in
 #[macro_use]
 extern crate getset;
 
-#[derive(Getters, Setters, MutGetters, Default)]
+#[derive(Getters, Setters, RefSetters, MutGetters, Default)]
+#[get] #[set] #[ref_set] #[get_mut]
 pub struct Foo<T> where T: Copy + Clone + Default {
     /// Doc comments are supported!
     /// Multiline, even.
-    #[get] #[set] #[get_mut]
     private: T,
 
     /// Doc comments are supported!
     /// Multiline, even.
-    #[get = "pub"] #[set = "pub"] #[get_mut = "pub"]
+    #[get = "pub"] #[set = "pub"] #[ref_set = "pub"] #[get_mut = "pub"]
     public: T,
 }
 
 fn main() {
-    let mut foo: Foo<i32> = Foo::default();
-    foo = foo.set_private(1);
+    let mut foo: Foo<i32> = Foo::default().set_private(1);
+    let private = *foo.private() + 1;
+    foo.ref_set_private(private);
     (*foo.private_mut()) += 1;
-    assert_eq!(*foo.private(), 2);
+    assert_eq!(*foo.private(), 3);
 }
 ```
 */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ use generate::{GenMode, GenParams};
 #[proc_macro_derive(Getters, attributes(get))]
 pub fn getters(input: TokenStream) -> TokenStream {
     // Parse the string representation
-    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for getters");
+    let ast: DeriveInput = syn::parse2(input.into()).expect("Couldn't parse for getters");
     let params = GenParams {
         attribute_name: "get",
         fn_name_prefix: "",
@@ -67,7 +67,7 @@ pub fn getters(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(MutGetters, attributes(get_mut))]
 pub fn mut_getters(input: TokenStream) -> TokenStream {
     // Parse the string representation
-    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for getters");
+    let ast: DeriveInput = syn::parse2(input.into()).expect("Couldn't parse for getters");
     let params = GenParams {
         attribute_name: "get_mut",
         fn_name_prefix: "",
@@ -84,7 +84,7 @@ pub fn mut_getters(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(RefSetters, attributes(ref_set))]
 pub fn ref_setters(input: TokenStream) -> TokenStream {
     // Parse the string representation
-    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for setters");
+    let ast: DeriveInput = syn::parse2(input.into()).expect("Couldn't parse for setters");
     let params = GenParams {
         attribute_name: "ref_set",
         fn_name_prefix: "ref_set_",
@@ -102,7 +102,7 @@ pub fn ref_setters(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(Setters, attributes(set))]
 pub fn setters(input: TokenStream) -> TokenStream {
     // Parse the string representation
-    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for setters");
+    let ast: DeriveInput = syn::parse2(input.into()).expect("Couldn't parse for setters");
     let params = GenParams {
         attribute_name: "set",
         fn_name_prefix: "set_",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub struct Foo<T> where T: Copy + Clone + Default {
 
 fn main() {
     let mut foo = Foo::default();
-    foo.set_private(1);
+    foo = foo.set_private(1);
     (*foo.private_mut()) += 1;
     assert_eq!(*foo.private(), 2);
 }
@@ -77,6 +77,24 @@ pub fn mut_getters(input: TokenStream) -> TokenStream {
 
     // Build the impl
     let gen = produce(&ast, &GenMode::GetMut, &params);
+    // Return the generated impl
+    gen.into()
+}
+
+#[proc_macro_derive(RefSetters, attributes(ref_set))]
+pub fn ref_setters(input: TokenStream) -> TokenStream {
+    // Parse the string representation
+    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for setters");
+    let params = GenParams {
+        attribute_name: "ref_set",
+        fn_name_prefix: "ref_set_",
+        fn_name_suffix: "",
+        global_attr: parse_global_attr(&ast.attrs, "ref_set"),
+    };
+
+    // Build the impl
+    let gen = produce(&ast, &GenMode::RefSet, &params);
+
     // Return the generated impl
     gen.into()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,6 @@ extern crate quote;
 extern crate proc_macro2;
 
 use proc_macro::TokenStream;
-use quote::Tokens;
 use syn::{DataStruct, DeriveInput, Meta};
 
 mod generate;
@@ -130,7 +129,7 @@ fn parse_global_attr(attrs: &[syn::Attribute], attribute_name: &str) -> Option<M
         }).last()
 }
 
-fn produce(ast: &DeriveInput, mode: &GenMode, params: &GenParams) -> Tokens {
+fn produce(ast: &DeriveInput, mode: &GenMode, params: &GenParams) -> proc_macro2::TokenStream {
     let name = &ast.ident;
     let generics = &ast.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub struct Foo<T> where T: Copy + Clone + Default {
 }
 
 fn main() {
-    let mut foo = Foo::default();
+    let mut foo: Foo<i32> = Foo::default();
     foo = foo.set_private(1);
     (*foo.private_mut()) += 1;
     assert_eq!(*foo.private(), 2);

--- a/tests/getters.rs
+++ b/tests/getters.rs
@@ -8,10 +8,10 @@ mod submodule {
     // For testing `pub(in super::other)`
     pub mod other {
         #[derive(Getters)]
+        #[get]
         pub struct Plain {
             /// A doc comment.
             /// Multiple lines, even.
-            #[get]
             private_accessible: usize,
 
             /// A doc comment.
@@ -40,10 +40,10 @@ mod submodule {
         }
 
         #[derive(Getters, Default)]
+        #[get]
         pub struct Generic<T: Copy + Clone + Default> {
             /// A doc comment.
             /// Multiple lines, even.
-            #[get]
             private_accessible: T,
 
             /// A doc comment.
@@ -63,13 +63,13 @@ mod submodule {
         }
 
         #[derive(Getters, Default)]
+        #[get]
         pub struct Where<T>
         where
             T: Copy + Clone + Default,
         {
             /// A doc comment.
             /// Multiple lines, even.
-            #[get]
             private_accessible: T,
 
             /// A doc comment.

--- a/tests/mut_getters.rs
+++ b/tests/mut_getters.rs
@@ -8,10 +8,10 @@ mod submodule {
     // For testing `pub(in super::other)`
     pub mod other {
         #[derive(MutGetters, Default)]
+        #[get_mut]
         pub struct Plain {
             /// A doc comment.
             /// Multiple lines, even.
-            #[get_mut]
             private_accessible: usize,
 
             /// A doc comment.
@@ -31,10 +31,10 @@ mod submodule {
         }
 
         #[derive(MutGetters, Default)]
+        #[get_mut]
         pub struct Generic<T: Copy + Clone + Default> {
             /// A doc comment.
             /// Multiple lines, even.
-            #[get_mut]
             private_accessible: T,
 
             /// A doc comment.
@@ -54,13 +54,13 @@ mod submodule {
         }
 
         #[derive(MutGetters, Default)]
+        #[get_mut]
         pub struct Where<T>
         where
             T: Copy + Clone + Default,
         {
             /// A doc comment.
             /// Multiple lines, even.
-            #[get_mut]
             private_accessible: T,
 
             /// A doc comment.

--- a/tests/ref_setters.rs
+++ b/tests/ref_setters.rs
@@ -7,132 +7,123 @@ use submodule::other::{Generic, Plain, Where};
 mod submodule {
     // For testing `pub(in super::other)`
     pub mod other {
-        #[derive(Setters, Default)]
-        #[set]
+        #[derive(RefSetters, Default)]
         pub struct Plain {
             /// A doc comment.
             /// Multiple lines, even.
+            #[ref_set]
             private_accessible: usize,
 
             /// A doc comment.
-            #[set = "pub"]
+            #[ref_set = "pub"]
             public_accessible: usize,
 
             /// This field is used for testing chaining.
-            #[set = "pub"]
+            #[ref_set = "pub"]
             second_public_accessible: bool,
             // /// A doc comment.
-            // #[set = "pub(crate)"]
+            // #[ref_set = "pub(crate)"]
             // crate_accessible: usize,
 
             // /// A doc comment.
-            // #[set = "pub(super)"]
+            // #[ref_set = "pub(super)"]
             // super_accessible: usize,
 
             // /// A doc comment.
-            // #[set = "pub(in super::other)"]
+            // #[ref_set = "pub(in super::other)"]
             // scope_accessible: usize,
         }
 
-        #[derive(Setters, Default)]
-        #[set]
+        #[derive(RefSetters, Default)]
         pub struct Generic<T: Copy + Clone + Default> {
             /// A doc comment.
             /// Multiple lines, even.
+            #[ref_set]
             private_accessible: T,
 
             /// A doc comment.
-            #[set = "pub"]
+            #[ref_set = "pub"]
             public_accessible: T,
             // /// A doc comment.
-            // #[set = "pub(crate)"]
+            // #[ref_set = "pub(crate)"]
             // crate_accessible: usize,
 
             // /// A doc comment.
-            // #[set = "pub(super)"]
+            // #[ref_set = "pub(super)"]
             // super_accessible: usize,
 
             // /// A doc comment.
-            // #[set = "pub(in super::other)"]
+            // #[ref_set = "pub(in super::other)"]
             // scope_accessible: usize,
         }
 
-        #[derive(Setters, Default)]
-        #[set]
+        #[derive(RefSetters, Default)]
         pub struct Where<T>
         where
             T: Copy + Clone + Default,
         {
             /// A doc comment.
             /// Multiple lines, even.
+            #[ref_set]
             private_accessible: T,
 
             /// A doc comment.
-            #[set = "pub"]
+            #[ref_set = "pub"]
             public_accessible: T,
             // /// A doc comment.
-            // #[set = "pub(crate)"]
+            // #[ref_set = "pub(crate)"]
             // crate_accessible: usize,
 
             // /// A doc comment.
-            // #[set = "pub(super)"]
+            // #[ref_set = "pub(super)"]
             // super_accessible: usize,
 
             // /// A doc comment.
-            // #[set = "pub(in super::other)"]
+            // #[ref_set = "pub(in super::other)"]
             // scope_accessible: usize,
         }
 
         #[test]
-        #[allow(unused_assignments)]
         fn test_plain() {
             let mut val = Plain::default();
-
-            val = val.set_private_accessible(1);
+            val.ref_set_private_accessible(1);
         }
 
         #[test]
-        #[allow(unused_assignments)]
         fn test_generic() {
             let mut val = Generic::default();
-
-            val = val.set_private_accessible(1);
+            val.ref_set_private_accessible(1);
         }
 
         #[test]
-        #[allow(unused_assignments)]
         fn test_where() {
             let mut val = Where::default();
-
-            val = val.set_private_accessible(1);
+            val.ref_set_private_accessible(1);
         }
     }
 }
 
 #[test]
-#[allow(unused_assignments)]
 fn test_plain() {
     let mut val = Plain::default();
-    val = val.set_public_accessible(1);
+    val.ref_set_public_accessible(1);
 }
 
 #[test]
-#[allow(unused_assignments)]
 fn test_generic() {
     let mut val = Generic::default();
-    val = val.set_public_accessible(1);
+    val.ref_set_public_accessible(1);
 }
 
 #[test]
-#[allow(unused_assignments)]
 fn test_where() {
     let mut val = Where::default();
-    val = val.set_public_accessible(1);
+    val.ref_set_public_accessible(1);
 }
 
 #[test]
-#[allow(unused_assignments)]
 fn test_chaining() {
-    let mut val = Plain::default().set_public_accessible(1);
-    val = val.set_second_public_accessible(true);
+    let mut val = Plain::default();
+    val.ref_set_public_accessible(1)
+        .ref_set_second_public_accessible(true);
 }

--- a/tests/ref_setters.rs
+++ b/tests/ref_setters.rs
@@ -85,19 +85,19 @@ mod submodule {
 
         #[test]
         fn test_plain() {
-            let mut val = Plain::default();
-            val.ref_set_private_accessible(1);
+            let mut val: Plain = Plain::default();
+            val.ref_set_private_accessible(1usize);
         }
 
         #[test]
         fn test_generic() {
-            let mut val = Generic::default();
+            let mut val: Generic<i32> = Generic::default();
             val.ref_set_private_accessible(1);
         }
 
         #[test]
         fn test_where() {
-            let mut val = Where::default();
+            let mut val: Where<i32> = Where::default();
             val.ref_set_private_accessible(1);
         }
     }
@@ -106,24 +106,24 @@ mod submodule {
 #[test]
 fn test_plain() {
     let mut val = Plain::default();
-    val.ref_set_public_accessible(1);
+    val.ref_set_public_accessible(1usize);
 }
 
 #[test]
 fn test_generic() {
-    let mut val = Generic::default();
-    val.ref_set_public_accessible(1);
+    let mut val: Generic<usize> = Generic::default();
+    val.ref_set_public_accessible(1usize);
 }
 
 #[test]
 fn test_where() {
-    let mut val = Where::default();
-    val.ref_set_public_accessible(1);
+    let mut val: Where<usize> = Where::default();
+    val.ref_set_public_accessible(1usize);
 }
 
 #[test]
 fn test_chaining() {
     let mut val = Plain::default();
-    val.ref_set_public_accessible(1)
+    val.ref_set_public_accessible(1usize)
         .ref_set_second_public_accessible(true);
 }

--- a/tests/setters.rs
+++ b/tests/setters.rs
@@ -8,10 +8,10 @@ mod submodule {
     // For testing `pub(in super::other)`
     pub mod other {
         #[derive(Setters, Default)]
+        #[set]
         pub struct Plain {
             /// A doc comment.
             /// Multiple lines, even.
-            #[set]
             private_accessible: usize,
 
             /// A doc comment.
@@ -35,10 +35,10 @@ mod submodule {
         }
 
         #[derive(Setters, Default)]
+        #[set]
         pub struct Generic<T: Copy + Clone + Default> {
             /// A doc comment.
             /// Multiple lines, even.
-            #[set]
             private_accessible: T,
 
             /// A doc comment.
@@ -58,13 +58,13 @@ mod submodule {
         }
 
         #[derive(Setters, Default)]
+        #[set]
         pub struct Where<T>
         where
             T: Copy + Clone + Default,
         {
             /// A doc comment.
             /// Multiple lines, even.
-            #[set]
             private_accessible: T,
 
             /// A doc comment.

--- a/tests/setters.rs
+++ b/tests/setters.rs
@@ -86,25 +86,19 @@ mod submodule {
         #[test]
         #[allow(unused_assignments)]
         fn test_plain() {
-            let mut val = Plain::default();
-
-            val = val.set_private_accessible(1);
+            let _ = Plain::default().set_private_accessible(1usize);
         }
 
         #[test]
         #[allow(unused_assignments)]
         fn test_generic() {
-            let mut val = Generic::default();
-
-            val = val.set_private_accessible(1);
+            let _: Generic<i32> = Generic::default().set_private_accessible(1);
         }
 
         #[test]
         #[allow(unused_assignments)]
         fn test_where() {
-            let mut val = Where::default();
-
-            val = val.set_private_accessible(1);
+            let _: Where<i32> = Where::default().set_private_accessible(1);
         }
     }
 }
@@ -113,26 +107,26 @@ mod submodule {
 #[allow(unused_assignments)]
 fn test_plain() {
     let mut val = Plain::default();
-    val = val.set_public_accessible(1);
+    val = val.set_public_accessible(1usize);
 }
 
 #[test]
 #[allow(unused_assignments)]
 fn test_generic() {
-    let mut val = Generic::default();
-    val = val.set_public_accessible(1);
+    let mut val: Generic<usize> = Generic::default();
+    val = val.set_public_accessible(1usize);
 }
 
 #[test]
 #[allow(unused_assignments)]
 fn test_where() {
-    let mut val = Where::default();
-    val = val.set_public_accessible(1);
+    let mut val: Where<usize> = Where::default();
+    val = val.set_public_accessible(1usize);
 }
 
 #[test]
 #[allow(unused_assignments)]
 fn test_chaining() {
-    let mut val = Plain::default().set_public_accessible(1);
+    let mut val = Plain::default().set_public_accessible(1usize);
     val = val.set_second_public_accessible(true);
 }


### PR DESCRIPTION
Hello. I made multiple changes to library
 
1. I added struct attribute handle. So now is not needed to add attribute to every field in struct, what can be cumbersome in big structs
2. Move Setters to RefSetters with ref_set method
3. Setters set method is now consume struct what allow chaining on creation
4. For setter methods use Into trait
5. Multiple little fixes, update dependencies