### PR TITLE
Struct attribute handle

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,5 +1,5 @@
-use proc_macro2::{Ident, Span};
 use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Ident, Span};
 use syn::{Attribute, Field, Lit, Meta, MetaNameValue};
 
 pub struct GenParams {
@@ -14,8 +14,44 @@ pub enum GenMode {
     GetMut,
 }
 
-fn attr_name(attr: &Attribute) -> Option<Ident> {
-    attr.interpret_meta().map(|v| v.name())
+pub fn attr_tuple(attr: &Attribute) -> Option<(Ident, Meta)> {
+    let meta = attr.interpret_meta();
+    meta.map(|v| (v.name(), v))
+}
+
+pub fn parse_visibility(attr: Option<&Meta>, meta_name: &str) -> Option<Ident> {
+    match attr {
+        // `#[get = "pub"]` or `#[set = "pub"]`
+        Some(Meta::NameValue(MetaNameValue {
+            lit: Lit::Str(ref s),
+            ident,
+            ..
+        })) => {
+            if ident == meta_name {
+                let visibility = Ident::new(&s.value(), Span::call_site());
+                Some(visibility)
+            } else {
+                None
+            }
+        }
+        // This currently doesn't work, but it might in the future.
+        //
+        // // `#[get(pub)]`
+        // MetaItem::List(_, ref vec) => {
+        //     let s = vec.iter().last().expect("No item found in attribute list.");
+        //     let visibility = match s {
+        //         &NestedMetaItem::MetaItem(MetaItem::Word(ref i)) => Ident::new(format!("{}", i)),
+        //         &NestedMetaItem::Literal(Lit::Str(ref l, _)) => Ident::from(l.clone()),
+        //         _ => panic!("Unexpected attribute parameters."),
+        //     };
+        //     quote! {
+        //         #visibility fn #fn_name(&self) -> &#ty {
+        //             &self.#field_name
+        //         }
+        //     }
+        // },
+        _ => None,
+    }
 }
 
 pub fn implement(field: &Field, mode: GenMode, params: GenParams) -> TokenStream2 {
@@ -32,106 +68,54 @@ pub fn implement(field: &Field, mode: GenMode, params: GenParams) -> TokenStream
     );
     let ty = field.ty.clone();
 
+    let mut doc = Vec::new();
     let attr = field
         .attrs
         .iter()
-        .filter(|v| attr_name(v).expect("attribute") == params.attribute_name)
-        .last();
+        .filter_map(|v| {
+            let tuple = attr_tuple(v).expect("attribute");
+            match tuple.0.to_string().as_str() {
+                "doc" => {
+                    doc.push(v);
+                    None
+                }
+                name if params.attribute_name == name => Some(tuple.1),
+                _ => None,
+            }
+        }).last();
 
-    let doc = field
-        .attrs
-        .iter()
-        .filter(|v| attr_name(v).expect("attribute") == "doc")
-        .collect::<Vec<_>>();
-
+    let visibility = parse_visibility(attr.as_ref(), params.attribute_name.as_ref());
     match attr {
-        Some(attr) => {
-            match attr.interpret_meta() {
-                // `#[get]` or `#[set]`
-                Some(Meta::Word(_)) => match mode {
-                    GenMode::Get => {
-                        quote! {
-                            #(#doc)*
-                            #[inline(always)]
-                            fn #fn_name(&self) -> &#ty {
-                                &self.#field_name
-                            }
-                        }
-                    }
-                    GenMode::Set => {
-                        quote! {
-                            #(#doc)*
-                            #[inline(always)]
-                            fn #fn_name(&mut self, val: #ty) -> &mut Self {
-                                self.#field_name = val;
-                                self
-                            }
-                        }
-                    }
-                    GenMode::GetMut => {
-                        quote! {
-                            #(#doc)*
-                            fn #fn_name(&mut self) -> &mut #ty {
-                                &mut self.#field_name
-                            }
-                        }
-                    }
-                },
-                // `#[get = "pub"]` or `#[set = "pub"]`
-                Some(Meta::NameValue(MetaNameValue {
-                    lit: Lit::Str(ref s),
-                    ..
-                })) => {
-                    let visibility = Ident::new(&s.value(), s.span());
-                    match mode {
-                        GenMode::Get => {
-                            quote! {
-                                #(#doc)*
-                                #[inline(always)]
-                                #visibility fn #fn_name(&self) -> &#ty {
-                                    &self.#field_name
-                                }
-                            }
-                        }
-                        GenMode::Set => {
-                            quote! {
-                                #(#doc)*
-                                #[inline(always)]
-                                #visibility fn #fn_name(&mut self, val: #ty) -> &mut Self {
-                                    self.#field_name = val;
-                                    self
-                                }
-                            }
-                        }
-                        GenMode::GetMut => {
-                            quote! {
-                                #(#doc)*
-                                #visibility fn #fn_name(&mut self) -> &mut #ty {
-                                    &mut self.#field_name
-                                }
-                            }
-                        }
+        Some(_) => match mode {
+            GenMode::Get => {
+                quote! {
+                    #(#doc)*
+                    #[inline(always)]
+                    #visibility fn #fn_name(&self) -> &#ty {
+                        &self.#field_name
                     }
                 }
-                // This currently doesn't work, but it might in the future.
-                //
-                // // `#[get(pub)]`
-                // MetaItem::List(_, ref vec) => {
-                //     let s = vec.iter().last().expect("No item found in attribute list.");
-                //     let visibility = match s {
-                //         &NestedMetaItem::MetaItem(MetaItem::Word(ref i)) => Ident::new(format!("{}", i)),
-                //         &NestedMetaItem::Literal(Lit::Str(ref l, _)) => Ident::from(l.clone()),
-                //         _ => panic!("Unexpected attribute parameters."),
-                //     };
-                //     quote! {
-                //         #visibility fn #fn_name(&self) -> &#ty {
-                //             &self.#field_name
-                //         }
-                //     }
-                // },
-                _ => panic!("Unexpected attribute parameters."),
             }
-        }
+            GenMode::Set => {
+                quote! {
+                    #(#doc)*
+                    #[inline(always)]
+                    #visibility fn #fn_name(&mut self, val: #ty) -> &mut Self {
+                        self.#field_name = val;
+                        self
+                    }
+                }
+            }
+            GenMode::GetMut => {
+                quote! {
+                    #(#doc)*
+                    #[inline(always)]
+                    #visibility fn #fn_name(&mut self) -> &mut #ty {
+                        &mut self.#field_name
+                    }
+                }
+            }
+        },
         // Don't need to do anything.
         None => quote!{},
     }

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -6,6 +6,7 @@ pub struct GenParams {
     pub attribute_name: &'static str,
     pub fn_name_prefix: &'static str,
     pub fn_name_suffix: &'static str,
+    pub global_attr: Option<Meta>,
 }
 
 pub enum GenMode {
@@ -54,7 +55,7 @@ pub fn parse_visibility(attr: Option<&Meta>, meta_name: &str) -> Option<Ident> {
     }
 }
 
-pub fn implement(field: &Field, mode: GenMode, params: GenParams) -> TokenStream2 {
+pub fn implement(field: &Field, mode: &GenMode, params: &GenParams) -> TokenStream2 {
     let field_name = field
         .clone()
         .ident
@@ -82,7 +83,8 @@ pub fn implement(field: &Field, mode: GenMode, params: GenParams) -> TokenStream
                 name if params.attribute_name == name => Some(tuple.1),
                 _ => None,
             }
-        }).last();
+        }).last()
+        .or_else(|| params.global_attr.clone());
 
     let visibility = parse_visibility(attr.as_ref(), params.attribute_name.as_ref());
     match attr {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,23 @@ fn main() {
     assert_eq!(*foo.private(), 2);
 }
 ```
+```compile_fail
+#[macro_use]
+extern crate getset;
+mod submodule {
+    #[derive(Getters, Default)]
+    #[get = "pub"]
+    pub struct Foo {
+        #[get]
+        private: i32,
+        public: i32,
+    }
+}
+fn main() {
+    let mut foo = submodule::Foo::default();
+    assert_eq!(*foo.private(), 2);
+}
+```
 */
 
 extern crate proc_macro;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ These macros are not intended to be used on fields which require custom logic in
 extern crate getset;
 
 #[derive(Getters, Setters, MutGetters, Default)]
+#[get = "pub"] #[set = "pub"] #[get_mut = "pub"]
 pub struct Foo<T> where T: Copy + Clone + Default {
     /// Doc comments are supported!
     /// Multiline, even.
@@ -20,7 +21,6 @@ pub struct Foo<T> where T: Copy + Clone + Default {
 
     /// Doc comments are supported!
     /// Multiline, even.
-    #[get = "pub"] #[set = "pub"] #[get_mut = "pub"]
     public: T,
 }
 
@@ -41,7 +41,7 @@ extern crate proc_macro2;
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
-use syn::{DataStruct, DeriveInput, Field};
+use syn::{DataStruct, DeriveInput, Meta};
 
 mod generate;
 use generate::{GenMode, GenParams};
@@ -49,20 +49,16 @@ use generate::{GenMode, GenParams};
 #[proc_macro_derive(Getters, attributes(get))]
 pub fn getters(input: TokenStream) -> TokenStream {
     // Parse the string representation
-    let ast = syn::parse(input).expect("Couldn't parse for getters");
+    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for getters");
+    let params = GenParams {
+        attribute_name: "get",
+        fn_name_prefix: "",
+        fn_name_suffix: "",
+        global_attr: parse_global_attr(&ast.attrs, "get"),
+    };
 
     // Build the impl
-    let gen = produce(&ast, |f| {
-        generate::implement(
-            f,
-            GenMode::Get,
-            GenParams {
-                attribute_name: "get",
-                fn_name_prefix: "",
-                fn_name_suffix: "",
-            },
-        )
-    });
+    let gen = produce(&ast, &GenMode::Get, &params);
 
     // Return the generated impl
     gen.into()
@@ -71,19 +67,16 @@ pub fn getters(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(MutGetters, attributes(get_mut))]
 pub fn mut_getters(input: TokenStream) -> TokenStream {
     // Parse the string representation
-    let ast = syn::parse(input).expect("Couldn't parse for getters");
+    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for getters");
+    let params = GenParams {
+        attribute_name: "get_mut",
+        fn_name_prefix: "",
+        fn_name_suffix: "_mut",
+        global_attr: parse_global_attr(&ast.attrs, "get_mut"),
+    };
+
     // Build the impl
-    let gen = produce(&ast, |f| {
-        generate::implement(
-            f,
-            GenMode::GetMut,
-            GenParams {
-                attribute_name: "get_mut",
-                fn_name_prefix: "",
-                fn_name_suffix: "_mut",
-            },
-        )
-    });
+    let gen = produce(&ast, &GenMode::GetMut, &params);
     // Return the generated impl
     gen.into()
 }
@@ -91,33 +84,45 @@ pub fn mut_getters(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(Setters, attributes(set))]
 pub fn setters(input: TokenStream) -> TokenStream {
     // Parse the string representation
-    let ast = syn::parse(input).expect("Couldn't parse for setters");
+    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for setters");
+    let params = GenParams {
+        attribute_name: "set",
+        fn_name_prefix: "set_",
+        fn_name_suffix: "",
+        global_attr: parse_global_attr(&ast.attrs, "set"),
+    };
 
     // Build the impl
-    let gen = produce(&ast, |f| {
-        generate::implement(
-            f,
-            GenMode::Set,
-            GenParams {
-                attribute_name: "set",
-                fn_name_prefix: "set_",
-                fn_name_suffix: "",
-            },
-        )
-    });
+    let gen = produce(&ast, &GenMode::Set, &params);
 
     // Return the generated impl
     gen.into()
 }
 
-fn produce(ast: &DeriveInput, worker: fn(&Field) -> TokenStream2) -> TokenStream2 {
+fn parse_global_attr(attrs: &[syn::Attribute], attribute_name: &str) -> Option<Meta> {
+    attrs
+        .iter()
+        .filter_map(|v| {
+            let (attr_name, meta) = generate::attr_tuple(v).expect("attribute");
+            if attr_name == attribute_name {
+                Some(meta)
+            } else {
+                None
+            }
+        }).last()
+}
+
+fn produce(ast: &DeriveInput, mode: &GenMode, params: &GenParams) -> TokenStream2 {
     let name = &ast.ident;
     let generics = &ast.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     // Is it a struct?
     if let syn::Data::Struct(DataStruct { ref fields, .. }) = ast.data {
-        let generated = fields.iter().map(worker).collect::<Vec<_>>();
+        let generated = fields
+            .iter()
+            .map(|f| generate::implement(f, mode, params))
+            .collect::<Vec<_>>();
 
         quote! {
             impl #impl_generics #name #ty_generics #where_clause {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ These macros are not intended to be used on fields which require custom logic in
 extern crate getset;
 
 #[derive(Getters, Setters, MutGetters, Default)]
-#[get = "pub"] #[set = "pub"] #[get_mut = "pub"]
 pub struct Foo<T> where T: Copy + Clone + Default {
     /// Doc comments are supported!
     /// Multiline, even.
@@ -21,6 +20,7 @@ pub struct Foo<T> where T: Copy + Clone + Default {
 
     /// Doc comments are supported!
     /// Multiline, even.
+    #[get = "pub"] #[set = "pub"] #[get_mut = "pub"]
     public: T,
 }
 
@@ -31,6 +31,8 @@ fn main() {
     assert_eq!(*foo.private(), 2);
 }
 ```
+
+Attributes can be set on struct level for all fields in struct, but field level attributes take precedence, so this can't compile.
 ```compile_fail
 #[macro_use]
 extern crate getset;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,8 @@ mod submodule {
 }
 fn main() {
     let mut foo = submodule::Foo::default();
-    assert_eq!(*foo.private(), 2);
+    // can't compile, because field getter is private
+    foo.private();
 }
 ```
 */

--- a/tests/getters.rs
+++ b/tests/getters.rs
@@ -8,10 +8,10 @@ mod submodule {
     // For testing `pub(in super::other)`
     pub mod other {
         #[derive(Getters)]
+        #[get]
         pub struct Plain {
             /// A doc comment.
             /// Multiple lines, even.
-            #[get]
             private_accessible: usize,
 
             /// A doc comment.
@@ -40,10 +40,10 @@ mod submodule {
         }
 
         #[derive(Getters, Default)]
+        #[get]
         pub struct Generic<T: Copy + Clone + Default> {
             /// A doc comment.
             /// Multiple lines, even.
-            #[get]
             private_accessible: T,
 
             /// A doc comment.
@@ -63,13 +63,13 @@ mod submodule {
         }
 
         #[derive(Getters, Default)]
+        #[get]
         pub struct Where<T>
         where
             T: Copy + Clone + Default,
         {
             /// A doc comment.
             /// Multiple lines, even.
-            #[get]
             private_accessible: T,
 
             /// A doc comment.

--- a/tests/mut_getters.rs
+++ b/tests/mut_getters.rs
@@ -8,10 +8,10 @@ mod submodule {
     // For testing `pub(in super::other)`
     pub mod other {
         #[derive(MutGetters, Default)]
+        #[get_mut]
         pub struct Plain {
             /// A doc comment.
             /// Multiple lines, even.
-            #[get_mut]
             private_accessible: usize,
 
             /// A doc comment.
@@ -31,10 +31,10 @@ mod submodule {
         }
 
         #[derive(MutGetters, Default)]
+        #[get_mut]
         pub struct Generic<T: Copy + Clone + Default> {
             /// A doc comment.
             /// Multiple lines, even.
-            #[get_mut]
             private_accessible: T,
 
             /// A doc comment.
@@ -54,13 +54,13 @@ mod submodule {
         }
 
         #[derive(MutGetters, Default)]
+        #[get_mut]
         pub struct Where<T>
         where
             T: Copy + Clone + Default,
         {
             /// A doc comment.
             /// Multiple lines, even.
-            #[get_mut]
             private_accessible: T,
 
             /// A doc comment.

--- a/tests/setters.rs
+++ b/tests/setters.rs
@@ -8,10 +8,10 @@ mod submodule {
     // For testing `pub(in super::other)`
     pub mod other {
         #[derive(Setters, Default)]
+        #[set]
         pub struct Plain {
             /// A doc comment.
             /// Multiple lines, even.
-            #[set]
             private_accessible: usize,
 
             /// A doc comment.
@@ -35,10 +35,10 @@ mod submodule {
         }
 
         #[derive(Setters, Default)]
+        #[set]
         pub struct Generic<T: Copy + Clone + Default> {
             /// A doc comment.
             /// Multiple lines, even.
-            #[set]
             private_accessible: T,
 
             /// A doc comment.
@@ -58,13 +58,13 @@ mod submodule {
         }
 
         #[derive(Setters, Default)]
+        #[set]
         pub struct Where<T>
         where
             T: Copy + Clone + Default,
         {
             /// A doc comment.
             /// Multiple lines, even.
-            #[set]
             private_accessible: T,
 
             /// A doc comment.


### PR DESCRIPTION
Handle struct attribute. So it is not needed to add attribute to every field in struct, what can be cumbersome in big structs.
And multiple refactors to remove duplication mostly