### PR TITLE
Update crate for Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ A procedural macro for generating the most basic getters and setters on fields.
 version = "0.0.7"
 authors = ["Ana Hobden <ana@hoverbear.org>"]
 license = "MIT"
+edition = "2018"
 
 categories = ["development-tools::procedural-macro-helpers"]
 keywords = ["macro", "getter", "setter", "getters", "setters"]

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,4 +1,4 @@
-use attr_name;
+use crate::attr_name;
 use proc_macro2::TokenStream as TokenStream2;
 use proc_macro2::{Ident, Span};
 use syn::{Attribute, Field, Lit, Meta, MetaNameValue};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use syn::{Attribute, DataStruct, DeriveInput, Ident, Meta};
 
 mod generate;
-use generate::{GenMode, GenParams};
+use crate::generate::{GenMode, GenParams};
 
 fn attr_name(attr: &Attribute) -> Option<Ident> {
     attr.interpret_meta().map(|v| v.name())

--- a/tests/getters.rs
+++ b/tests/getters.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate getset;
 
-use submodule::other::{Generic, Plain, Where};
+use crate::submodule::other::{Generic, Plain, Where};
 
 // For testing `pub(super)`
 mod submodule {

--- a/tests/mut_getters.rs
+++ b/tests/mut_getters.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate getset;
 
-use submodule::other::{Generic, Plain, Where};
+use crate::submodule::other::{Generic, Plain, Where};
 
 // For testing `pub(super)`
 mod submodule {

--- a/tests/setters.rs
+++ b/tests/setters.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate getset;
 
-use submodule::other::{Generic, Plain, Where};
+use crate::submodule::other::{Generic, Plain, Where};
 
 // For testing `pub(super)`
 mod submodule {


### PR DESCRIPTION
Run 'cargo fix --edition' to update crate for Rust 2018