### PR TITLE
Do not fail on non-"meta" attributes

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -53,8 +53,9 @@ fn has_prefix_attr(f: &Field) -> bool {
     let inner = f
         .attrs
         .iter()
-        .filter_map(|v| {
-            let meta = v.parse_meta().expect("Could not get attribute");
+        .filter_map(|v| v.parse_meta().ok())
+        .filter_map(|meta| {
+            let meta = ;
             if ["get", "get_copy"]
                 .iter()
                 .any(|ident| meta.path().is_ident(ident))
@@ -104,8 +105,8 @@ pub fn implement(field: &Field, mode: &GenMode, params: &GenParams) -> TokenStre
     let attr = field
         .attrs
         .iter()
-        .filter_map(|v| {
-            let meta = v.parse_meta().expect("attribute");
+        .filter_map(|v| v.parse_meta().ok())
+        .filter_map(|meta| {
             if meta.path().is_ident("doc") {
                 doc.push(v);
                 None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,14 +234,8 @@ pub fn setters(input: TokenStream) -> TokenStream {
 fn parse_global_attr(attrs: &[syn::Attribute], attribute_name: &str) -> Option<Meta> {
     attrs
         .iter()
-        .filter_map(|v| {
-            let meta = v.parse_meta().expect("attribute");
-            if meta.path().is_ident(attribute_name) {
-                Some(meta)
-            } else {
-                None
-            }
-        })
+        .filter_map(|v| v.parse_meta().ok()) // non "meta" attributes are not our concern
+        .filter(|meta| meta.path().is_ident(attribute_name))
         .last()
 }
 


### PR DESCRIPTION
Attributes are [no longer ought to be in the "meta" form](https://github.com/rust-lang/rust/issues/55208).

For example, this is absolutely valid code:
```rust
use getset::CopyGetters;
use clap::{Clap, crate_version};

#[derive(Clap, CopyGetters)]
#[clap(version(crate_version!()))]
pub struct Config {}
```

but your crate fails to parse this with 
```
error: proc-macro derive panicked
 --> src\main.rs:6:16
  |
6 | #[derive(Clap, CopyGetters)]
  |                ^^^^^^^^^^^
  |
  = help: message: attribute: Error("expected `,`")

error: aborting due to previous error
```

This PR resolves the issue.