### PR TITLE
Make error messages point to the origin location

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ proc-macro = true
 quote = "1"
 syn = "1"
 proc-macro2 = { version = "1", default-features = false }
+proc-macro-error = "0.4"

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,6 +1,7 @@
 use proc_macro2::TokenStream as TokenStream2;
 use proc_macro2::{Ident, Span};
-use syn::{self, Field, Lit, Meta, MetaNameValue, Visibility};
+use syn::{self, spanned::Spanned, Field, Lit, Meta, MetaNameValue, Visibility};
+use proc_macro_error::{ResultExt, abort};
 
 pub struct GenParams {
     pub attribute_name: &'static str,
@@ -38,7 +39,10 @@ pub fn parse_visibility(attr: Option<&Meta>, meta_name: &str) -> Option<Visibili
                 s.value()
                     .split(' ')
                     .find(|v| *v != "with_prefix")
-                    .map(|v| syn::parse(v.parse().unwrap()).expect("invalid visibility found"))
+                    .map(|v| {
+                        syn::parse_str(v)
+                            .unwrap_or_else(|_| abort!(s.span(), "invalid visibility found"))
+                    })
             } else {
                 None
             }
@@ -82,7 +86,7 @@ pub fn implement(field: &Field, mode: &GenMode, params: &GenParams) -> TokenStre
     let field_name = field
         .clone()
         .ident
-        .expect("Expected the field to have a name");
+        .unwrap_or_else(|| abort!(field.span(), "Expected the field to have a name"));
 
     let fn_name = Ident::new(
         &format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,14 +156,16 @@ extern crate proc_macro2;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use syn::{DataStruct, DeriveInput, Meta};
+use proc_macro_error::{proc_macro_error, abort_call_site, ResultExt};
 
 mod generate;
 use crate::generate::{GenMode, GenParams};
 
 #[proc_macro_derive(Getters, attributes(get, with_prefix))]
+#[proc_macro_error]
 pub fn getters(input: TokenStream) -> TokenStream {
     // Parse the string representation
-    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for getters");
+    let ast: DeriveInput = syn::parse(input).expect_or_abort("Couldn't parse for getters");
     let params = GenParams {
         attribute_name: "get",
         fn_name_prefix: "",
@@ -179,9 +181,10 @@ pub fn getters(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(CopyGetters, attributes(get_copy, with_prefix))]
+#[proc_macro_error]
 pub fn copy_getters(input: TokenStream) -> TokenStream {
     // Parse the string representation
-    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for getters");
+    let ast: DeriveInput = syn::parse(input).expect_or_abort("Couldn't parse for getters");
     let params = GenParams {
         attribute_name: "get_copy",
         fn_name_prefix: "",
@@ -197,9 +200,10 @@ pub fn copy_getters(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(MutGetters, attributes(get_mut))]
+#[proc_macro_error]
 pub fn mut_getters(input: TokenStream) -> TokenStream {
     // Parse the string representation
-    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for getters");
+    let ast: DeriveInput = syn::parse(input).expect_or_abort("Couldn't parse for getters");
     let params = GenParams {
         attribute_name: "get_mut",
         fn_name_prefix: "",
@@ -214,9 +218,10 @@ pub fn mut_getters(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(Setters, attributes(set))]
+#[proc_macro_error]
 pub fn setters(input: TokenStream) -> TokenStream {
     // Parse the string representation
-    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for setters");
+    let ast: DeriveInput = syn::parse(input).expect_or_abort("Couldn't parse for setters");
     let params = GenParams {
         attribute_name: "set",
         fn_name_prefix: "set_",
@@ -264,6 +269,6 @@ fn produce(ast: &DeriveInput, mode: &GenMode, params: &GenParams) -> TokenStream
         }
     } else {
         // Nope. This is an Enum. We cannot handle these!
-        panic!("#[derive(Getters)] is only defined for structs, not for enums!");
+        abort_call_site!("#[derive(Getters)] is only defined for structs, not for enums!");
     }
 }


### PR DESCRIPTION
This is how the error from #47 would look like
```
error: attribute: expected `,`
 --> src\main.rs:5:29
  |
5 | #[clap(version(crate_version!()))]
  |                             ^
```