### PR TITLE
Add alternative #[getset(...)] syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ proc-macro = true
 quote = "1"
 syn = "1"
 proc-macro2 = { version = "1", default-features = false }
+proc-macro-error = "0.4"

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -57,8 +57,8 @@ fn has_prefix_attr(f: &Field) -> bool {
     let inner = f
         .attrs
         .iter()
-        .filter_map(|v| {
-            let meta = v.parse_meta().expect("Could not get attribute");
+        .filter_map(|v| v.parse_meta().ok())
+        .filter_map(|meta| {
             if ["get", "get_copy"]
                 .iter()
                 .any(|ident| meta.path().is_ident(ident))
@@ -108,8 +108,8 @@ pub fn implement(field: &Field, mode: &GenMode, params: &GenParams) -> TokenStre
     let attr = field
         .attrs
         .iter()
-        .filter_map(|v| {
-            let meta = v.parse_meta().expect("attribute");
+        .filter_map(|v| v.parse_meta().ok().map(|meta| (v, meta)))
+        .filter_map(|(v, meta)| {
             if meta.path().is_ident("doc") {
                 doc.push(v);
                 None

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,6 +1,7 @@
 use proc_macro2::TokenStream as TokenStream2;
 use proc_macro2::{Ident, Span};
-use syn::{self, Field, Lit, Meta, MetaNameValue, Visibility};
+use syn::{self, spanned::Spanned, Field, Lit, Meta, MetaNameValue, Visibility};
+use proc_macro_error::abort;
 
 pub struct GenParams {
     pub attribute_name: &'static str,
@@ -38,7 +39,10 @@ pub fn parse_visibility(attr: Option<&Meta>, meta_name: &str) -> Option<Visibili
                 s.value()
                     .split(' ')
                     .find(|v| *v != "with_prefix")
-                    .map(|v| syn::parse(v.parse().unwrap()).expect("invalid visibility found"))
+                    .map(|v| {
+                        syn::parse_str(v)
+                            .unwrap_or_else(|_| abort!(s.span(), "invalid visibility found"))
+                    })
             } else {
                 None
             }
@@ -82,7 +86,7 @@ pub fn implement(field: &Field, mode: &GenMode, params: &GenParams) -> TokenStre
     let field_name = field
         .clone()
         .ident
-        .expect("Expected the field to have a name");
+        .unwrap_or_else(|| abort!(field.span(), "Expected the field to have a name"));
 
     let fn_name = Ident::new(
         &format!(

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream as TokenStream2;
 use proc_macro2::{Ident, Span};
-use syn::{self, spanned::Spanned, Field, Lit, Meta, MetaNameValue, Visibility};
 use proc_macro_error::abort;
+use syn::{self, spanned::Spanned, Field, Lit, Meta, MetaNameValue, Visibility};
 
 pub struct GenParams {
     pub attribute_name: &'static str,
@@ -36,13 +36,10 @@ pub fn parse_visibility(attr: Option<&Meta>, meta_name: &str) -> Option<Visibili
             ..
         })) => {
             if path.is_ident(meta_name) {
-                s.value()
-                    .split(' ')
-                    .find(|v| *v != "with_prefix")
-                    .map(|v| {
-                        syn::parse_str(v)
-                            .unwrap_or_else(|_| abort!(s.span(), "invalid visibility found"))
-                    })
+                s.value().split(' ').find(|v| *v != "with_prefix").map(|v| {
+                    syn::parse_str(v)
+                        .unwrap_or_else(|_| abort!(s.span(), "invalid visibility found"))
+                })
             } else {
                 None
             }
@@ -58,15 +55,10 @@ fn has_prefix_attr(f: &Field) -> bool {
         .attrs
         .iter()
         .filter_map(|v| v.parse_meta().ok())
-        .filter_map(|meta| {
-            if ["get", "get_copy"]
+        .filter(|meta| {
+            ["get", "get_copy"]
                 .iter()
                 .any(|ident| meta.path().is_ident(ident))
-            {
-                Some(meta)
-            } else {
-                None
-            }
         })
         .last();
     match inner {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,14 +149,16 @@ extern crate proc_macro2;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use syn::{DataStruct, DeriveInput, Meta};
+use proc_macro_error::{proc_macro_error, abort_call_site, ResultExt};
 
 mod generate;
 use crate::generate::{GenMode, GenParams};
 
 #[proc_macro_derive(Getters, attributes(get, with_prefix))]
+#[proc_macro_error]
 pub fn getters(input: TokenStream) -> TokenStream {
     // Parse the string representation
-    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for getters");
+    let ast: DeriveInput = syn::parse(input).expect_or_abort("Couldn't parse for getters");
     let params = GenParams {
         attribute_name: "get",
         fn_name_prefix: "",
@@ -172,9 +174,10 @@ pub fn getters(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(CopyGetters, attributes(get_copy, with_prefix))]
+#[proc_macro_error]
 pub fn copy_getters(input: TokenStream) -> TokenStream {
     // Parse the string representation
-    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for getters");
+    let ast: DeriveInput = syn::parse(input).expect_or_abort("Couldn't parse for getters");
     let params = GenParams {
         attribute_name: "get_copy",
         fn_name_prefix: "",
@@ -190,9 +193,10 @@ pub fn copy_getters(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(MutGetters, attributes(get_mut))]
+#[proc_macro_error]
 pub fn mut_getters(input: TokenStream) -> TokenStream {
     // Parse the string representation
-    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for getters");
+    let ast: DeriveInput = syn::parse(input).expect_or_abort("Couldn't parse for getters");
     let params = GenParams {
         attribute_name: "get_mut",
         fn_name_prefix: "",
@@ -207,9 +211,10 @@ pub fn mut_getters(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(Setters, attributes(set))]
+#[proc_macro_error]
 pub fn setters(input: TokenStream) -> TokenStream {
     // Parse the string representation
-    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for setters");
+    let ast: DeriveInput = syn::parse(input).expect_or_abort("Couldn't parse for setters");
     let params = GenParams {
         attribute_name: "set",
         fn_name_prefix: "set_",
@@ -257,6 +262,6 @@ fn produce(ast: &DeriveInput, mode: &GenMode, params: &GenParams) -> TokenStream
         }
     } else {
         // Nope. This is an Enum. We cannot handle these!
-        panic!("#[derive(Getters)] is only defined for structs, not for enums!");
+        abort_call_site!("#[derive(Getters)] is only defined for structs, not for enums!");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,8 +148,8 @@ extern crate proc_macro2;
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
+use proc_macro_error::{abort_call_site, proc_macro_error, ResultExt};
 use syn::{DataStruct, DeriveInput, Meta};
-use proc_macro_error::{proc_macro_error, abort_call_site, ResultExt};
 
 mod generate;
 use crate::generate::{GenMode, GenParams};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,14 +232,8 @@ pub fn setters(input: TokenStream) -> TokenStream {
 fn parse_global_attr(attrs: &[syn::Attribute], attribute_name: &str) -> Option<Meta> {
     attrs
         .iter()
-        .filter_map(|v| {
-            let meta = v.parse_meta().expect("attribute");
-            if meta.path().is_ident(attribute_name) {
-                Some(meta)
-            } else {
-                None
-            }
-        })
+        .filter_map(|v| v.parse_meta().ok()) // non "meta" attributes are not our concern
+        .filter(|meta| meta.path().is_ident(attribute_name))
         .last()
 }
 

--- a/tests/getset.rs
+++ b/tests/getset.rs
@@ -1,0 +1,121 @@
+#[macro_use]
+extern crate getset;
+
+use crate::submodule::other::{Generic, Plain, Where};
+
+// For testing `pub(super)`
+mod submodule {
+    // For testing `pub(in super::other)`
+    pub mod other {
+        #[derive(MutGetters, Getters, Default)]
+        #[getset(get_mut)]
+        pub struct Plain {
+            /// A doc comment.
+            /// Multiple lines, even.
+            private_accessible: usize,
+
+            /// A doc comment.
+            #[getset(get = "pub", get_mut = "pub")]
+            public_accessible: usize,
+            // /// A doc comment.
+            // #[get_mut = "pub(crate)"]
+            // crate_accessible: usize,
+
+            // /// A doc comment.
+            // #[get_mut = "pub(super)"]
+            // super_accessible: usize,
+
+            // /// A doc comment.
+            // #[get_mut = "pub(in super::other)"]
+            // scope_accessible: usize,
+        }
+
+        #[derive(MutGetters, Getters, Default)]
+        #[getset(get_mut)]
+        pub struct Generic<T: Copy + Clone + Default> {
+            /// A doc comment.
+            /// Multiple lines, even.
+            private_accessible: T,
+
+            /// A doc comment.
+            #[getset(get = "pub", get_mut = "pub")]
+            public_accessible: T,
+            // /// A doc comment.
+            // #[get_mut = "pub(crate)"]
+            // crate_accessible: usize,
+
+            // /// A doc comment.
+            // #[get_mut = "pub(super)"]
+            // super_accessible: usize,
+
+            // /// A doc comment.
+            // #[get_mut = "pub(in super::other)"]
+            // scope_accessible: usize,
+        }
+
+        #[derive(MutGetters, Getters, Default)]
+        #[getset(get_mut)]
+        pub struct Where<T>
+        where
+            T: Copy + Clone + Default,
+        {
+            /// A doc comment.
+            /// Multiple lines, even.
+            private_accessible: T,
+
+            /// A doc comment.
+            #[getset(get = "pub", get_mut = "pub")]
+            public_accessible: T,
+            // /// A doc comment.
+            // #[get_mut = "pub(crate)"]
+            // crate_accessible: usize,
+
+            // /// A doc comment.
+            // #[get_mut = "pub(super)"]
+            // super_accessible: usize,
+
+            // /// A doc comment.
+            // #[get_mut = "pub(in super::other)"]
+            // scope_accessible: usize,
+        }
+
+        #[test]
+        fn test_plain() {
+            let mut val = Plain::default();
+            (*val.private_accessible_mut()) += 1;
+        }
+
+        #[test]
+        fn test_generic() {
+            let mut val = Generic::<usize>::default();
+            (*val.private_accessible_mut()) += 1;
+        }
+
+        #[test]
+        fn test_where() {
+            let mut val = Where::<usize>::default();
+            (*val.private_accessible_mut()) += 1;
+        }
+    }
+}
+
+#[test]
+fn test_plain() {
+    let mut val = Plain::default();
+    let _ = val.public_accessible();
+    (*val.public_accessible_mut()) += 1;
+}
+
+#[test]
+fn test_generic() {
+    let mut val = Generic::<usize>::default();
+    let _ = val.public_accessible();
+    (*val.public_accessible_mut()) += 1;
+}
+
+#[test]
+fn test_where() {
+    let mut val = Where::<usize>::default();
+    let _ = val.public_accessible();
+    (*val.public_accessible_mut()) += 1;
+}


### PR DESCRIPTION
This PR adds the alternative `#[getset(get, set, ...)]` syntax as discussed in #5 

Closes #5