### PR TITLE
Revert "Make error messages point to the origin location"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,3 @@ proc-macro = true
 quote = "1"
 syn = "1"
 proc-macro2 = { version = "1", default-features = false }
-proc-macro-error = "0.4"

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,7 +1,6 @@
 use proc_macro2::TokenStream as TokenStream2;
 use proc_macro2::{Ident, Span};
-use syn::{self, spanned::Spanned, Field, Lit, Meta, MetaNameValue, Visibility};
-use proc_macro_error::{ResultExt, abort};
+use syn::{self, Field, Lit, Meta, MetaNameValue, Visibility};
 
 pub struct GenParams {
     pub attribute_name: &'static str,
@@ -39,10 +38,7 @@ pub fn parse_visibility(attr: Option<&Meta>, meta_name: &str) -> Option<Visibili
                 s.value()
                     .split(' ')
                     .find(|v| *v != "with_prefix")
-                    .map(|v| {
-                        syn::parse_str(v)
-                            .unwrap_or_else(|_| abort!(s.span(), "invalid visibility found"))
-                    })
+                    .map(|v| syn::parse(v.parse().unwrap()).expect("invalid visibility found"))
             } else {
                 None
             }
@@ -87,7 +83,7 @@ pub fn implement(field: &Field, mode: &GenMode, params: &GenParams) -> TokenStre
     let field_name = field
         .clone()
         .ident
-        .unwrap_or_else(|| abort!(field.span(), "Expected the field to have a name"));
+        .expect("Expected the field to have a name");
 
     let fn_name = Ident::new(
         &format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,16 +156,14 @@ extern crate proc_macro2;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use syn::{DataStruct, DeriveInput, Meta};
-use proc_macro_error::{proc_macro_error, abort_call_site, ResultExt};
 
 mod generate;
 use crate::generate::{GenMode, GenParams};
 
 #[proc_macro_derive(Getters, attributes(get, with_prefix))]
-#[proc_macro_error]
 pub fn getters(input: TokenStream) -> TokenStream {
     // Parse the string representation
-    let ast: DeriveInput = syn::parse(input).expect_or_abort("Couldn't parse for getters");
+    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for getters");
     let params = GenParams {
         attribute_name: "get",
         fn_name_prefix: "",
@@ -181,10 +179,9 @@ pub fn getters(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(CopyGetters, attributes(get_copy, with_prefix))]
-#[proc_macro_error]
 pub fn copy_getters(input: TokenStream) -> TokenStream {
     // Parse the string representation
-    let ast: DeriveInput = syn::parse(input).expect_or_abort("Couldn't parse for getters");
+    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for getters");
     let params = GenParams {
         attribute_name: "get_copy",
         fn_name_prefix: "",
@@ -200,10 +197,9 @@ pub fn copy_getters(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(MutGetters, attributes(get_mut))]
-#[proc_macro_error]
 pub fn mut_getters(input: TokenStream) -> TokenStream {
     // Parse the string representation
-    let ast: DeriveInput = syn::parse(input).expect_or_abort("Couldn't parse for getters");
+    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for getters");
     let params = GenParams {
         attribute_name: "get_mut",
         fn_name_prefix: "",
@@ -218,10 +214,9 @@ pub fn mut_getters(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(Setters, attributes(set))]
-#[proc_macro_error]
 pub fn setters(input: TokenStream) -> TokenStream {
     // Parse the string representation
-    let ast: DeriveInput = syn::parse(input).expect_or_abort("Couldn't parse for setters");
+    let ast: DeriveInput = syn::parse(input).expect("Couldn't parse for setters");
     let params = GenParams {
         attribute_name: "set",
         fn_name_prefix: "set_",
@@ -263,6 +258,6 @@ fn produce(ast: &DeriveInput, mode: &GenMode, params: &GenParams) -> TokenStream
         }
     } else {
         // Nope. This is an Enum. We cannot handle these!
-        abort_call_site!("#[derive(Getters)] is only defined for structs, not for enums!");
+        panic!("#[derive(Getters)] is only defined for structs, not for enums!");
     }
 }


### PR DESCRIPTION
Reverts Hoverbear/getset#48, @CreepySkeleton can reopen it later and we can merge it after it passes CI.