### PR TITLE
Revert "Do not fail on non-"meta" attributes"

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -57,9 +57,8 @@ fn has_prefix_attr(f: &Field) -> bool {
     let inner = f
         .attrs
         .iter()
-        .filter_map(|v| v.parse_meta().ok())
-        .filter_map(|meta| {
-            let meta = ;
+        .filter_map(|v| {
+            let meta = v.parse_meta().expect("Could not get attribute");
             if ["get", "get_copy"]
                 .iter()
                 .any(|ident| meta.path().is_ident(ident))
@@ -109,8 +108,8 @@ pub fn implement(field: &Field, mode: &GenMode, params: &GenParams) -> TokenStre
     let attr = field
         .attrs
         .iter()
-        .filter_map(|v| v.parse_meta().ok())
-        .filter_map(|meta| {
+        .filter_map(|v| {
+            let meta = v.parse_meta().expect("attribute");
             if meta.path().is_ident("doc") {
                 doc.push(v);
                 None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,8 +239,14 @@ pub fn setters(input: TokenStream) -> TokenStream {
 fn parse_global_attr(attrs: &[syn::Attribute], attribute_name: &str) -> Option<Meta> {
     attrs
         .iter()
-        .filter_map(|v| v.parse_meta().ok()) // non "meta" attributes are not our concern
-        .filter(|meta| meta.path().is_ident(attribute_name))
+        .filter_map(|v| {
+            let meta = v.parse_meta().expect("attribute");
+            if meta.path().is_ident(attribute_name) {
+                Some(meta)
+            } else {
+                None
+            }
+        })
         .last()
 }
 


### PR DESCRIPTION
Reverts Hoverbear/getset#47, @CreepySkeleton can reopen it later and we can merge it after it passes CI.