### PR TITLE
Allow raw identifiers.

### DIFF
--- a/tests/raw_identifiers.rs
+++ b/tests/raw_identifiers.rs
@@ -1,0 +1,57 @@
+#[macro_use]
+extern crate getset;
+
+#[derive(CopyGetters, Default, Getters, MutGetters, Setters)]
+struct RawIdentifiers {
+    #[get]
+    r#type: usize,
+    #[get_copy]
+    r#move: usize,
+    #[get_mut]
+    r#union: usize,
+    #[set]
+    r#enum: usize,
+    #[get = "with_prefix"]
+    r#const: usize,
+    #[get_copy = "with_prefix"]
+    r#if: usize,
+    // Ensure having no gen mode doesn't break things.
+    #[allow(dead_code)]
+    r#loop: usize,
+}
+
+#[test]
+fn test_get() {
+    let val = RawIdentifiers::default();
+    let _ = val.r#type();
+}
+
+#[test]
+fn test_get_copy() {
+    let val = RawIdentifiers::default();
+    let _ = val.r#move();
+}
+
+#[test]
+fn test_get_mut() {
+    let mut val = RawIdentifiers::default();
+    let _ = val.union_mut();
+}
+
+#[test]
+fn test_set() {
+    let mut val = RawIdentifiers::default();
+    val.set_enum(42);
+}
+
+#[test]
+fn test_get_with_prefix() {
+    let val = RawIdentifiers::default();
+    let _ = val.get_const();
+}
+
+#[test]
+fn test_get_copy_with_prefix() {
+    let val = RawIdentifiers::default();
+    let _ = val.get_if();
+}


### PR DESCRIPTION
Solution to issue #63. 

`proc_macro2::Ident::new()` doesn't allow raw identifiers, and [`proc_macro2::Ident::new_raw()`](https://docs.rs/proc-macro2/1.0.24/proc_macro2/struct.Ident.html#method.new_raw) provided by the same crate is unstable. Therefore, the solution here is to check if the identifier begins with "r#', and if so, keep the "r#" as long as there are no added prefixes and suffixes. 

In the other cases, we can use `syn::ext::IdentExt::unraw()` to remove the rawness of the identifier.