### PR TITLE
Add option for skipping fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,35 @@ fn main() {
     let val = foo.get_field();
 }
 ```
+
+Skipping setters and getters generation for a field when struct level attribute is used
+is possible with `#[getset(skip)]`.
+
+```rust
+use getset::{CopyGetters, Setters};
+
+#[derive(CopyGetters, Setters)]
+#[getset(get_copy, set)]
+pub struct Foo {
+    // If the field was not skipped, the compiler would complain about moving
+    // a non-copyable type in copy getter.
+    #[getset(skip)]
+    skipped: String,
+
+    field1: usize,
+    field2: usize,
+}
+
+impl Foo {
+    // It is possible to write getters and setters manually,
+    // possibly with a custom logic.
+    fn skipped(&self) -> &str {
+        &self.skipped
+    }
+
+    fn set_skipped(&mut self, val: &str) -> &mut Self {
+        self.skipped = val.to_string();
+        self
+    }
+}
+```

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -151,6 +151,8 @@ pub fn implement(field: &Field, params: &GenParams) -> TokenStream2 {
 
     let visibility = parse_visibility(attr.as_ref(), params.mode.name());
     match attr {
+        // Generate nothing for skipped field.
+        Some(meta) if meta.path().is_ident("skip") => quote! {},
         Some(_) => match params.mode {
             GenMode::Get => {
                 quote! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ foo.public();
 ```
 
 For some purposes, it's useful to have the `get_` prefix on the getters for
-either legacy of compatability reasons. It is done with `with_prefix`.
+either legacy of compatibility reasons. It is done with `with_prefix`.
 
 ```rust
 use getset::{Getters, MutGetters, CopyGetters, Setters};
@@ -140,6 +140,38 @@ pub struct Foo {
 
 let mut foo = Foo::default();
 let val = foo.get_field();
+```
+
+Skipping setters and getters generation for a field when struct level attribute is used
+is possible with `#[getset(skip)]`.
+
+```rust
+use getset::{CopyGetters, Setters};
+
+#[derive(CopyGetters, Setters)]
+#[getset(get_copy, set)]
+pub struct Foo {
+    // If the field was not skipped, the compiler would complain about moving
+    // a non-copyable type in copy getter.
+    #[getset(skip)]
+    skipped: String,
+
+    field1: usize,
+    field2: usize,
+}
+
+impl Foo {
+    // It is possible to write getters and setters manually,
+    // possibly with a custom logic.
+    fn skipped(&self) -> &str {
+        &self.skipped
+    }
+
+    fn set_skipped(&mut self, val: &str) -> &mut Self {
+        self.skipped = val.to_string();
+        self
+    }
+}
 ```
 */
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,7 +304,7 @@ fn parse_attr(attr: &syn::Attribute, mode: GenMode) -> Option<Meta> {
                 skip
             } else {
                 abort!(
-                    last.or(collected.pop()).unwrap().path().span(),
+                    last.or_else(|| collected.pop()).unwrap().path().span(),
                     "use of setters and getters with skip is invalid"
                 );
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,12 +242,13 @@ fn parse_attr(attr: &syn::Attribute, mode: GenMode) -> Option<Meta> {
                 if !(meta.path().is_ident("get")
                     || meta.path().is_ident("get_copy")
                     || meta.path().is_ident("get_mut")
-                    || meta.path().is_ident("set"))
+                    || meta.path().is_ident("set")
+                    || meta.path().is_ident("skip"))
                 {
                     abort!(meta.path().span(), "unknown setter or getter")
                 }
             })
-            .filter(|meta| meta.path().is_ident(mode.name()))
+            .filter(|meta| meta.path().is_ident(mode.name()) || meta.path().is_ident("skip"))
             .last()
     } else {
         attr.parse_meta()

--- a/tests/skip.rs
+++ b/tests/skip.rs
@@ -10,7 +10,6 @@ pub struct Plain {
     non_copyable: String,
 
     copyable: usize,
-
     // Invalid use of skip -- compilation error.
     // #[getset(skip, get_copy)]
     // non_copyable2: String,

--- a/tests/skip.rs
+++ b/tests/skip.rs
@@ -1,19 +1,35 @@
 #[macro_use]
 extern crate getset;
 
-#[derive(CopyGetters)]
-#[get_copy]
+#[derive(CopyGetters, Setters)]
+#[getset(get_copy, set)]
 pub struct Plain {
-    /// A doc comment.
+    // If the field was not skipped, the compiler would complain about moving a
+    // non-copyable type.
     #[getset(skip)]
     non_copyable: String,
 
     copyable: usize,
+
+    // Invalid use of skip -- compilation error.
+    // #[getset(skip, get_copy)]
+    // non_copyable2: String,
+
+    // Invalid use of skip -- compilation error.
+    // #[getset(get_copy, skip)]
+    // non_copyable2: String,
 }
 
 impl Plain {
     fn custom_non_copyable(&self) -> &str {
         &self.non_copyable
+    }
+
+    // If the field was not skipped, the compiler would complain about duplicate
+    // definitions of `set_non_copyable`.
+    fn set_non_copyable(&mut self, val: String) -> &mut Self {
+        self.non_copyable = val;
+        self
     }
 }
 
@@ -28,7 +44,8 @@ impl Default for Plain {
 
 #[test]
 fn test_plain() {
-    let val = Plain::default();
+    let mut val = Plain::default();
     val.copyable();
     val.custom_non_copyable();
+    val.set_non_copyable("bar".to_string());
 }

--- a/tests/skip.rs
+++ b/tests/skip.rs
@@ -1,0 +1,34 @@
+#[macro_use]
+extern crate getset;
+
+#[derive(CopyGetters)]
+#[get_copy]
+pub struct Plain {
+    /// A doc comment.
+    #[getset(skip)]
+    non_copyable: String,
+
+    copyable: usize,
+}
+
+impl Plain {
+    fn custom_non_copyable(&self) -> &str {
+        &self.non_copyable
+    }
+}
+
+impl Default for Plain {
+    fn default() -> Self {
+        Plain {
+            non_copyable: "foo".to_string(),
+            copyable: 3,
+        }
+    }
+}
+
+#[test]
+fn test_plain() {
+    let val = Plain::default();
+    val.copyable();
+    val.custom_non_copyable();
+}


### PR DESCRIPTION
Implements #72 

The idea is similar to [serde's skip](https://serde.rs/field-attrs.html#skip). The getter/setter is not implemented for fields that are marked `#[getset(skip)]`. So for:

```rust
#[derive(CopyGetters)]
#[get_copy]
pub struct Plain {
    #[getset(skip)]
    non_copyable: String,
    copyable: usize,
}
```

only `fn copyable(&self) -> usize` getter is generated. This feature makes sense for larger structs, where using struct-level attribute is convenient for brevity, but the user still wants to ignore a subset of fields. It is possible to achieve this behavior in the current version by annotating each field with a corresponding `getset` attribute and not annotating the fields for which the getter/setter should not be generated.

This PR lacks thorough testing and documentation, I wanted to be sure this is a way to go before writing the tests and docs.

Open questions I can think of:
1. Current implementation accepts multiple identifiers inside `getset` attribute. For the example above, it means that if I use `#[getset(get_copy, skip)]`, it silently swallows the "get_copy" part and skips the field, but if I use `#[getset(skip, get_copy)]`, the last identifier (i.e., "get_copy") is taken and the getter is generated (resulting into a compilation error for moving a non-copyable value). This is inconsistent and confusing for the user. I think it should be forbidden to use any other identifier if `skip` is present, but there is also point 2.
2. A user might want to skip only a particular getter/setter. For example, the struct could derive both `Getters` and `Setters` and the user wants to omit the setter part on a field. Should `getset` support this too by a more granular syntax (e.g., `getset(skip(get))` or `get(skip)` or `getset(skip_get)`) or is it out of scope? (The `getset(skip_get)` syntax is inspired by [serde's `skip_serializing`](https://serde.rs/field-attrs.html#skip_serializing).)