### PR TITLE
feat: add `into`, `optional`, `const` and `skip` options with enhanced visibility parser (closes #30, #31)

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,8 +1,8 @@
 use proc_macro_error2::abort;
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use syn::{
-    self, Expr, Field, GenericArgument, Lit, Meta, MetaNameValue, PathArguments, Type, Visibility,
-    ext::IdentExt, spanned::Spanned,
+    self, Expr, Field, GenericArgument, Lit, Meta, PathArguments, Type, Visibility, ext::IdentExt,
+    spanned::Spanned,
 };
 
 use self::GenMode::{Get, GetClone, GetCopy, GetMut, Set, SetWith};

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -117,6 +117,7 @@ fn split_attr_string(s: &str) -> Vec<String> {
 }
 
 // Helper function to parse attributes
+#[derive(Default)]
 pub struct FieldAttributes {
     pub visibility: Option<Visibility>,
     pub with_prefix: bool,
@@ -124,19 +125,6 @@ pub struct FieldAttributes {
     pub into: bool,
     pub is_const: bool,
     pub skip: bool,
-}
-
-impl Default for FieldAttributes {
-    fn default() -> Self {
-        FieldAttributes {
-            visibility: None,
-            with_prefix: false,
-            optional: false,
-            into: false,
-            is_const: false,
-            skip: false,
-        }
-    }
 }
 
 pub fn parse_attributes(attr: Option<&Meta>) -> FieldAttributes {
@@ -186,18 +174,17 @@ pub fn parse_attributes(attr: Option<&Meta>) -> FieldAttributes {
     }
 
     // Validate skip is not combined with other attributes
-    if attrs.skip {
-        if attrs.with_prefix
+    if attrs.skip
+        & (attrs.with_prefix
             || attrs.optional
             || attrs.into
             || attrs.is_const
-            || attrs.visibility.is_some()
-        {
-            abort!(
-                nv.value.span(),
-                "The 'skip' attribute cannot be combined with any other parameters"
-            );
-        }
+            || attrs.visibility.is_some())
+    {
+        abort!(
+            nv.value.span(),
+            "The 'skip' attribute cannot be combined with any other parameters"
+        );
     }
 
     attrs

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,7 +1,8 @@
 use proc_macro_error2::abort;
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use syn::{
-    self, Expr, Field, Lit, Meta, MetaNameValue, Visibility, ext::IdentExt, spanned::Spanned,
+    self, Expr, Field, GenericArgument, Lit, Meta, MetaNameValue, PathArguments, Type, Visibility,
+    ext::IdentExt, spanned::Spanned,
 };
 
 use self::GenMode::{Get, GetClone, GetCopy, GetMut, Set, SetWith};
@@ -78,21 +79,128 @@ fn parse_vis_str(s: &str, span: proc_macro2::Span) -> Visibility {
     }
 }
 
-// Helper function to parse visibility attribute
-pub fn parse_visibility(attr: Option<&Meta>, meta_name: &str) -> Option<Visibility> {
-    let meta = attr?;
-    let Meta::NameValue(MetaNameValue { value, path, .. }) = meta else {
-        return None;
-    };
+// Helper to split attribute string while respecting parentheses
+fn split_attr_string(s: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut paren_depth = 0;
 
-    if !path.is_ident(meta_name) {
-        return None;
+    for c in s.chars() {
+        match c {
+            '(' => {
+                paren_depth += 1;
+                current.push(c);
+            }
+            ')' => {
+                if paren_depth > 0 {
+                    paren_depth -= 1;
+                }
+                current.push(c);
+            }
+            ' ' if paren_depth == 0 => {
+                if !current.is_empty() {
+                    tokens.push(current.trim().to_string());
+                    current.clear();
+                }
+            }
+            _ => {
+                current.push(c);
+            }
+        }
     }
 
-    let value_str = expr_to_string(value)?;
-    let vis_str = value_str.split(' ').find(|v| *v != "with_prefix")?;
+    if !current.is_empty() {
+        tokens.push(current.trim().to_string());
+    }
 
-    Some(parse_vis_str(vis_str, value.span()))
+    tokens
+}
+
+// Helper function to parse attributes
+pub struct FieldAttributes {
+    pub visibility: Option<Visibility>,
+    pub with_prefix: bool,
+    pub optional: bool,
+    pub into: bool,
+    pub is_const: bool,
+    pub skip: bool,
+}
+
+impl Default for FieldAttributes {
+    fn default() -> Self {
+        FieldAttributes {
+            visibility: None,
+            with_prefix: false,
+            optional: false,
+            into: false,
+            is_const: false,
+            skip: false,
+        }
+    }
+}
+
+pub fn parse_attributes(attr: Option<&Meta>) -> FieldAttributes {
+    let mut attrs = FieldAttributes::default();
+
+    let meta = match attr {
+        Some(m) => m,
+        None => return attrs,
+    };
+
+    let Meta::NameValue(nv) = meta else {
+        return attrs;
+    };
+
+    let s = match expr_to_string(&nv.value) {
+        Some(s) => s,
+        None => return attrs,
+    };
+
+    // Split while respecting parentheses
+    let tokens = split_attr_string(&s);
+
+    let mut found_visibility = false;
+
+    for token in tokens {
+        match token.as_str() {
+            "with_prefix" => attrs.with_prefix = true,
+            "optional" => attrs.optional = true,
+            "into" => attrs.into = true,
+            "const" => attrs.is_const = true,
+            "skip" => attrs.skip = true,
+            _ => {
+                if !found_visibility {
+                    // Parse visibility - might contain spaces in parentheses
+                    let vis = parse_vis_str(&token, nv.value.span());
+                    attrs.visibility = Some(vis);
+                    found_visibility = true;
+                } else {
+                    abort!(
+                        nv.value.span(),
+                        "Unexpected token in attribute: '{}'",
+                        token
+                    );
+                }
+            }
+        }
+    }
+
+    // Validate skip is not combined with other attributes
+    if attrs.skip {
+        if attrs.with_prefix
+            || attrs.optional
+            || attrs.into
+            || attrs.is_const
+            || attrs.visibility.is_some()
+        {
+            abort!(
+                nv.value.span(),
+                "The 'skip' attribute cannot be combined with any other parameters"
+            );
+        }
+    }
+
+    attrs
 }
 
 /// Some users want legacy/compatibility.
@@ -126,11 +234,40 @@ fn has_prefix_attr(f: &Field, params: &GenParams) -> bool {
     field_attr_has_prefix || global_attr_has_prefix
 }
 
+// Helper to extract inner type from Option<T>
+fn extract_option_inner(ty: &Type) -> Option<Type> {
+    if let Type::Path(type_path) = ty {
+        if let Some(segment) = type_path.path.segments.last() {
+            if segment.ident == "Option" {
+                if let PathArguments::AngleBracketed(args) = &segment.arguments {
+                    if let Some(GenericArgument::Type(inner)) = args.args.first() {
+                        return Some(inner.clone());
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
 pub fn implement(field: &Field, params: &GenParams) -> TokenStream2 {
     let field_name = field
         .ident
         .clone()
         .unwrap_or_else(|| abort!(field.span(), "Expected the field to have a name"));
+
+    let attr = field
+        .attrs
+        .iter()
+        .filter_map(|v| parse_attr(v, params.mode))
+        .next_back()
+        .or_else(|| params.global_attr.clone());
+
+    let attrs = parse_attributes(attr.as_ref());
+
+    if attr.is_none_or(|attr| attr.path().is_ident("skip")) || attrs.skip {
+        return quote! {};
+    }
 
     let fn_name = if !has_prefix_attr(field, params)
         && (params.mode.is_get())
@@ -158,76 +295,125 @@ pub fn implement(field: &Field, params: &GenParams) -> TokenStream2 {
 
     let doc = field.attrs.iter().filter(|v| v.meta.path().is_ident("doc"));
 
-    let attr = field
-        .attrs
-        .iter()
-        .filter_map(|v| parse_attr(v, params.mode))
-        .next_back()
-        .or_else(|| params.global_attr.clone());
+    let visibility = attrs
+        .visibility
+        .unwrap_or_else(|| parse_vis_str("pub(self)", Span::call_site()));
+    let const_qual = if attrs.is_const {
+        quote! { const }
+    } else {
+        quote! {}
+    };
 
-    let visibility = parse_visibility(attr.as_ref(), params.mode.name());
-    match attr {
-        // Generate nothing for skipped field
-        Some(meta) if meta.path().is_ident("skip") => quote! {},
-        Some(_) => match params.mode {
-            Get => {
-                quote! {
+    match params.mode {
+        Get | GetClone | GetCopy => {
+            // Validate attribute compatibility for getters
+            if attrs.optional {
+                abort!(
+                    field.span(),
+                    "`optional` attribute is only allowed for Setters and WithSetters"
+                );
+            }
+            if attrs.into {
+                abort!(
+                    field.span(),
+                    "`into` attribute is only allowed for Setters and WithSetters"
+                );
+            }
+
+            match params.mode {
+                Get => quote! {
                     #(#doc)*
                     #[inline(always)]
-                    #visibility fn #fn_name(&self) -> &#ty {
+                    #visibility #const_qual fn #fn_name(&self) -> &#ty {
                         &self.#field_name
                     }
-                }
-            }
-            GetClone => {
-                quote! {
+                },
+                GetClone => quote! {
                     #(#doc)*
                     #[inline(always)]
-                    #visibility fn #fn_name(&self) -> #ty {
+                    #visibility #const_qual fn #fn_name(&self) -> #ty {
                         self.#field_name.clone()
                     }
-                }
-            }
-            GetCopy => {
-                quote! {
+                },
+                GetCopy => quote! {
                     #(#doc)*
                     #[inline(always)]
-                    #visibility fn #fn_name(&self) -> #ty {
+                    #visibility #const_qual fn #fn_name(&self) -> #ty {
                         self.#field_name
                     }
-                }
+                },
+                _ => unreachable!(),
             }
-            Set => {
-                quote! {
+        }
+        Set | SetWith => {
+            let (arg_ty, set_expr) = if attrs.optional {
+                if let Some(inner_ty) = extract_option_inner(&ty) {
+                    if attrs.into {
+                        (
+                            quote! { impl ::std::convert::Into<#inner_ty> },
+                            quote! { Some(val.into()) },
+                        )
+                    } else {
+                        (quote! { #inner_ty }, quote! { Some(val) })
+                    }
+                } else {
+                    abort!(
+                        ty.span(),
+                        "optional attribute requires Option<T> field type"
+                    )
+                }
+            } else if attrs.into {
+                (
+                    quote! { impl ::std::convert::Into<#ty> },
+                    quote! { val.into() },
+                )
+            } else {
+                (quote! { #ty }, quote! { val })
+            };
+
+            match params.mode {
+                Set => quote! {
                     #(#doc)*
                     #[inline(always)]
-                    #visibility fn #fn_name(&mut self, val: #ty) -> &mut Self {
-                        self.#field_name = val;
+                    #visibility #const_qual fn #fn_name(&mut self, val: #arg_ty) -> &mut Self {
+                        self.#field_name = #set_expr;
                         self
                     }
-                }
-            }
-            GetMut => {
-                quote! {
+                },
+                SetWith => quote! {
                     #(#doc)*
                     #[inline(always)]
-                    #visibility fn #fn_name(&mut self) -> &mut #ty {
-                        &mut self.#field_name
-                    }
-                }
-            }
-            SetWith => {
-                quote! {
-                    #(#doc)*
-                    #[inline(always)]
-                    #visibility fn #fn_name(mut self, val: #ty) -> Self {
-                        self.#field_name = val;
+                    #visibility #const_qual fn #fn_name(mut self, val: #arg_ty) -> Self {
+                        self.#field_name = #set_expr;
                         self
                     }
+                },
+                _ => unreachable!(),
+            }
+        }
+        GetMut => {
+            // Validate attribute compatibility for mutable getters
+            if attrs.optional {
+                abort!(
+                    field.span(),
+                    "`optional` attribute is only allowed for Setters and WithSetters"
+                );
+            }
+            if attrs.into {
+                abort!(
+                    field.span(),
+                    "`into` attribute is only allowed for Setters and WithSetters"
+                );
+            }
+
+            quote! {
+                #(#doc)*
+                #[inline(always)]
+                #visibility #const_qual fn #fn_name(&mut self) -> &mut #ty {
+                    &mut self.#field_name
                 }
             }
-        },
-        None => quote! {},
+        }
     }
 }
 
@@ -239,76 +425,139 @@ pub fn implement_for_unnamed(field: &Field, params: &GenParams) -> TokenStream2 
         .filter_map(|v| parse_attr(v, params.mode))
         .next_back()
         .or_else(|| params.global_attr.clone());
-    let ty = field.ty.clone();
-    let visibility = parse_visibility(attr.as_ref(), params.mode.name());
+    let attrs = parse_attributes(attr.as_ref());
 
-    match attr {
-        // Generate nothing for skipped field
-        Some(meta) if meta.path().is_ident("skip") => quote! {},
-        Some(_) => match params.mode {
-            Get => {
-                let fn_name = Ident::new("get", Span::call_site());
-                quote! {
+    if attr.is_none() || attrs.skip {
+        return quote! {};
+    }
+
+    let ty = field.ty.clone();
+    let visibility = attrs
+        .visibility
+        .unwrap_or_else(|| parse_vis_str("pub(self)", Span::call_site()));
+    let const_qual = if attrs.is_const {
+        quote! { const }
+    } else {
+        quote! {}
+    };
+
+    match params.mode {
+        Get | GetClone | GetCopy => {
+            // Validate attribute compatibility for getters
+            if attrs.optional {
+                abort!(
+                    field.span(),
+                    "`optional` attribute is only allowed for Setters and WithSetters"
+                );
+            }
+            if attrs.into {
+                abort!(
+                    field.span(),
+                    "`into` attribute is only allowed for Setters and WithSetters"
+                );
+            }
+
+            let fn_name = Ident::new("get", Span::call_site());
+            match params.mode {
+                Get => quote! {
                     #(#doc)*
                     #[inline(always)]
-                    #visibility fn #fn_name(&self) -> &#ty {
+                    #visibility #const_qual fn #fn_name(&self) -> &#ty {
                         &self.0
                     }
-                }
-            }
-            GetClone => {
-                let fn_name = Ident::new("get", Span::call_site());
-                quote! {
+                },
+                GetClone => quote! {
                     #(#doc)*
                     #[inline(always)]
-                    #visibility fn #fn_name(&self) -> #ty {
+                    #visibility #const_qual fn #fn_name(&self) -> #ty {
                         self.0.clone()
                     }
-                }
-            }
-            GetCopy => {
-                let fn_name = Ident::new("get", Span::call_site());
-                quote! {
+                },
+                GetCopy => quote! {
                     #(#doc)*
                     #[inline(always)]
-                    #visibility fn #fn_name(&self) -> #ty {
+                    #visibility #const_qual fn #fn_name(&self) -> #ty {
                         self.0
                     }
-                }
+                },
+                _ => unreachable!(),
             }
-            Set => {
-                let fn_name = Ident::new("set", Span::call_site());
-                quote! {
+        }
+        Set | SetWith => {
+            let (arg_ty, set_expr) = if attrs.optional {
+                if let Some(inner_ty) = extract_option_inner(&ty) {
+                    if attrs.into {
+                        (
+                            quote! { impl ::std::convert::Into<#inner_ty> },
+                            quote! { Some(val.into()) },
+                        )
+                    } else {
+                        (quote! { #inner_ty }, quote! { Some(val) })
+                    }
+                } else {
+                    abort!(
+                        ty.span(),
+                        "optional attribute requires Option<T> field type"
+                    )
+                }
+            } else if attrs.into {
+                (
+                    quote! { impl ::std::convert::Into<#ty> },
+                    quote! { val.into() },
+                )
+            } else {
+                (quote! { #ty }, quote! { val })
+            };
+
+            let fn_name = match params.mode {
+                Set => Ident::new("set", Span::call_site()),
+                SetWith => Ident::new("set_with", Span::call_site()),
+                _ => unreachable!(),
+            };
+
+            match params.mode {
+                Set => quote! {
                     #(#doc)*
                     #[inline(always)]
-                    #visibility fn #fn_name(&mut self, val: #ty) -> &mut Self {
-                        self.0 = val;
+                    #visibility #const_qual fn #fn_name(&mut self, val: #arg_ty) -> &mut Self {
+                        self.0 = #set_expr;
                         self
                     }
-                }
-            }
-            GetMut => {
-                let fn_name = Ident::new("get_mut", Span::call_site());
-                quote! {
+                },
+                SetWith => quote! {
                     #(#doc)*
                     #[inline(always)]
-                    #visibility fn #fn_name(&mut self) -> &mut #ty {
-                        &mut self.0
-                    }
-                }
-            }
-            SetWith => {
-                let fn_name = Ident::new("set_with", Span::call_site());
-                quote! {
-                    #(#doc)*
-                    #[inline(always)]
-                    #visibility fn #fn_name(mut self, val: #ty) -> Self {
-                        self.0 = val;
+                    #visibility #const_qual fn #fn_name(mut self, val: #arg_ty) -> Self {
+                        self.0 = #set_expr;
                         self
                     }
+                },
+                _ => unreachable!(),
+            }
+        }
+        GetMut => {
+            // Validate attribute compatibility for mutable getters
+            if attrs.optional {
+                abort!(
+                    field.span(),
+                    "`optional` attribute is only allowed for Setters and WithSetters"
+                );
+            }
+            if attrs.into {
+                abort!(
+                    field.span(),
+                    "`into` attribute is only allowed for Setters and WithSetters"
+                );
+            }
+
+            let fn_name = Ident::new("get_mut", Span::call_site());
+            quote! {
+                #(#doc)*
+                #[inline(always)]
+                #visibility #const_qual fn #fn_name(&mut self) -> &mut #ty {
+                    &mut self.0
                 }
             }
-        },
-        None => quote! {},
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,19 +424,30 @@ fn produce(ast: &DeriveInput, params: &GenParams) -> TokenStream2 {
             // This unwrap is safe because we know there is exactly one field
             let field = fields.iter().next().unwrap();
             let generated = generate::implement_for_unnamed(field, params);
-
-            quote! {
-                impl #impl_generics #name #ty_generics #where_clause {
-                    #generated
+            if !generated.is_empty() {
+                quote! {
+                    impl #impl_generics #name #ty_generics #where_clause {
+                        #generated
+                    }
                 }
+            } else {
+                quote! {}
             }
         } else {
-            let generated = fields.iter().map(|f| generate::implement(f, params));
+            let generated = fields
+                .iter()
+                .map(|f| generate::implement(f, params))
+                .filter(|g| !g.is_empty())
+                .collect::<Vec<_>>();
 
-            quote! {
-                impl #impl_generics #name #ty_generics #where_clause {
-                    #(#generated)*
+            if !generated.is_empty() {
+                quote! {
+                    impl #impl_generics #name #ty_generics #where_clause {
+                        #(#generated)*
+                    }
                 }
+            } else {
+                quote! {}
             }
         }
     } else {


### PR DESCRIPTION
This PR introduces `into`, `optional`, `const`, and `skip` options for related macros.
- `into` is only allowed for `set` and `set_with`. It enables setters to accept `std::convert::Into<T>` for a field type `T`.
Example:
```rust
#[derive(Setters, Default)]
pub struct Config {
    #[getset(set = "into")]
    name: String,
}

fn example() {
    Config::default().set_name("val");
}
```

- `optional` is only allowed for `set` and `set_with`, and the field must be an `Option<T>` type. It allows setters to accept `T` instead of `Option<T>`.
Example:
```rust
#[derive(Setters, Default)]
pub struct Config {
    #[getset(set = "optional")]
    name: Option<String>,
}
fn example() {
    Config::default().set_name("val".to_string());
}
```

* `optional` and `into` can be used together:

```rust
#[derive(Setters, Default)]
pub struct Config {
    #[getset(set = "into optional")]
    name: Option<String>,
}
fn example() {
    Config::default().set_name("val");
}
```

- `const` makes the related method `const`. Due to its strict constraints, any compile-time errors that arise when using it must be handled by the user.
Example:
```rust
#[derive(Getters)]
struct MathConstants {
    #[getset(get = "pub const")]
    pi: f64,
}

const PI: &f64 = MathConstants { pi: 3.14159 }.pi();
```

- `skip` excludes the attribute individually. It is incompatible with other options and must be used alone for that specific attribute. Note that it's different than the skip attribute.
Example:
```rust
#[derive(CopyGetters, Getters, Default)]
#[getset(get_copy)]
pub struct Config {
    #[getset(get_copy = "skip", get)]
    name: String,
    id: usize,
    number: u32,
}
fn example() {
    let name: &String = Config::default().name();
}
```

Additionally, the visibility parser has been improved to support more complex visibility specifiers, such as `pub(in crate)`.